### PR TITLE
Remove usage of Prototype.js (Ajax.Request -> fetch)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>4.68</version>
     <relativePath />
   </parent>
 
@@ -42,8 +42,7 @@
   <url>https://wiki.jenkins-ci.org/display/JENKINS/PollSCM+Plugin</url>
 
   <properties>
-    <jenkins.version>1.580.3</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.361.4</jenkins.version>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,13 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/pollscm-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/pollscm-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/pollscm-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/pollscm-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
-  <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
+  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/src/main/resources/org/jenkinsci/plugins/pollscm/PollNowAction/action.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pollscm/PollNowAction/action.jelly
@@ -34,7 +34,12 @@ THE SOFTWARE.
                 href="${h.getActionUrl(it.url,action)}/polling" onclick="${'return poll_' + id + '(this)'}" post="true"/>
         <script>
             function poll_${id}(a) {
-                new Ajax.Request(a.href);
+                fetch(a.href, {
+                  method: "post",
+                  headers: crumb.wrap({
+                    "Content-Type": "application/x-www-form-urlencoded",
+                  }),
+                });
                 hoverNotification('${%Poll scheduled}',a.parentNode);
                 return false;
             }

--- a/src/main/resources/org/jenkinsci/plugins/pollscm/PollNowAction/action.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pollscm/PollNowAction/action.jelly
@@ -36,9 +36,7 @@ THE SOFTWARE.
             function poll_${id}(a) {
                 fetch(a.href, {
                   method: "post",
-                  headers: crumb.wrap({
-                    "Content-Type": "application/x-www-form-urlencoded",
-                  }),
+                  headers: crumb.wrap({}),
                 });
                 hoverNotification('${%Poll scheduled}',a.parentNode);
                 return false;


### PR DESCRIPTION
## Remove usages of Prototype.js (Ajax.Request -> fetch)

- Add Jenkinsfile for ci.jenkins.io, test with Java 11 and Java 17
- Use valid SCM URL instead of invalid git:// url
- Require Java 11 and Jenkins 2.361.4 or newer
- Replace Ajex.Request with fetch

### Testing done

Tested interactively with the Chrome debugger to confirm that the new code is being called and that it performs the poll as expected.

Change is based on the same pattern as was used in a recent pull request to Jenkins core.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
