### PR TITLE
Use jenkins.baseline to match archetype

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,12 @@
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
 
 version: 2
 updates:
-
-  # Maintain dependencies for maven
-  - package-ecosystem: "maven"
-    directory: "/"
-    labels:
-      - "dependencies"
-    schedule:
-      interval: "monthly"
-
-  # Maintain dependencies for GitHub actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    labels:
-      - "skip-changelog"
-    schedule:
-      interval: "monthly"
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.452.4</jenkins.version>
+    <jenkins.baseline>2.452</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
## Use jenkins.baseline to match archetype

The Jenkins plugin archetype uses jenkins.baseline to prevent inconsistencies between the minimum required Jenkins version and the Jenkins plugin bill of materials version.  Use the same technique in this plugin.

### Testing done

Confirmed that compilation passes.  Will rely on ci.jenkins.io to check automated tests.  Behavior preserving transformation.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
